### PR TITLE
Allow using an arbitrary number of ports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-midi"
 version = "0.2.0"
-authors = ["beau trepp <beautrepp@gmail.com>"]
+authors = ["beau trepp <beautrepp@gmail.com>", "Florian Jung <flo@windfis.ch>"]
 edition = "2018"
 description = "A usb-midi implementation for usb-device"
 homepage = "https://github.com/btrepp/usbd-midi"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let usb_bus = UsbBus::new(usb);
 
-    let mut midi = MidiClass::new(&usb_bus);
+    let mut midi = MidiClass::new(&usb_bus, 1, 1);
 
     let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x5e4))
         .product("MIDI Test")
@@ -69,3 +69,19 @@ fn main() -> ! {
     }
 }
 ```
+
+## Using more than one MIDI port
+
+Calling `MidiClass::new(&usb_bus, N, M);` with `N, M >= 1` to provide more
+than one input or output port requires the `control-buffer-256` feature of
+the usb-device crate:
+
+Cargo.toml:
+```
+usb-device = { version = ">=0.2.1", features = ["control-buffer-256"] }
+```
+
+Up to 5 in/out pairs can be used this way until we again run out of buffer
+space. Note that exceeding the available buffer space will silently fail
+to send the descriptors correctly, no obvious `panic!` will hint the
+actual problem.

--- a/src/data/usb/constants.rs
+++ b/src/data/usb/constants.rs
@@ -7,6 +7,7 @@ pub const USB_MIDISTREAMING_SUBCLASS: u8 =0x03;
 pub const MIDI_IN_JACK_SUBTYPE : u8 = 0x02;
 pub const MIDI_OUT_JACK_SUBTYPE : u8 = 0x03;
 pub const EMBEDDED : u8 = 0x01;
+pub const EXTERNAL : u8 = 0x02;
 pub const CS_INTERFACE: u8 = 0x24;
 pub const CS_ENDPOINT: u8 = 0x25;
 pub const HEADER_SUBTYPE: u8 = 0x01;

--- a/src/midi_device.rs
+++ b/src/midi_device.rs
@@ -34,7 +34,7 @@ impl<B: UsbBus> MidiClass<'_, B> {
     /// depending on the terminology).
     /// Note that a maximum of 16 in and 16 out jacks are supported.
     pub fn new(alloc: &UsbBusAllocator<B>, n_in_jacks: u8, n_out_jacks: u8) -> core::result::Result<MidiClass<'_, B>, InvalidArguments>  {
-        if n_in_jacks >= 16 || n_out_jacks >= 16 {
+        if n_in_jacks > 16 || n_out_jacks > 16 {
             return Err(InvalidArguments);
         }
         Ok(MidiClass {

--- a/src/midi_device.rs
+++ b/src/midi_device.rs
@@ -117,7 +117,7 @@ impl<B: UsbBus> UsbClass<B> for MidiClass<'_, B> {
         let midi_streaming_start_byte = writer.position();
         let midi_streaming_total_length =
             7 + (self.n_in_jacks + self.n_out_jacks) as usize * (MIDI_IN_SIZE + MIDI_OUT_SIZE) as usize
-            + 9 + (4+self.n_out_jacks as usize) + 9 + (4+self.n_in_jacks as usize);
+            + 7 + (4+self.n_out_jacks as usize) + 7 + (4+self.n_in_jacks as usize);
 
         //Streaming extra info
         writer.write( // len = 7
@@ -190,7 +190,7 @@ impl<B: UsbBus> UsbClass<B> for MidiClass<'_, B> {
             0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 // jack mappings. must be filled in and cropped.
         ];
 
-        writer.endpoint(&self.standard_bulkout)?; // len = 9
+        writer.endpoint(&self.standard_bulkout)?; // len = 7
 
         endpoint_data[1] = self.n_out_jacks;
         for i in 0..self.n_out_jacks {
@@ -201,7 +201,7 @@ impl<B: UsbBus> UsbClass<B> for MidiClass<'_, B> {
             &endpoint_data[0..2+self.n_out_jacks as usize]
         )?;
 
-        writer.endpoint(&self.standard_bulkin)?; // len = 9
+        writer.endpoint(&self.standard_bulkin)?; // len = 7
         endpoint_data[1] = self.n_in_jacks;
         for i in 0..self.n_in_jacks {
             endpoint_data[2 + i as usize] = self.out_jack_id_emb(i);

--- a/src/midi_device.rs
+++ b/src/midi_device.rs
@@ -47,7 +47,10 @@ impl<B: UsbBus> MidiClass<'_, B> {
         })
     }
 
-    pub fn send_message(&mut self, usb_midi:UsbMidiEventPacket) -> Result<usize> {
+    pub fn send_bytes(&mut self, buffer: [u8; 4]) -> Result<usize> {
+        self.standard_bulkin.write(&buffer)
+    }
+    pub fn send_message(&mut self, usb_midi: UsbMidiEventPacket) -> Result<usize> {
         let bytes : [u8;MIDI_PACKET_SIZE] = usb_midi.into();
         self.standard_bulkin.write(&bytes)
     }

--- a/src/midi_device.rs
+++ b/src/midi_device.rs
@@ -4,7 +4,7 @@ use crate::data::usb::constants::*;
 use crate::data::usb_midi::usb_midi_event_packet::{UsbMidiEventPacket, MidiPacketParsingError};
 
 const MIDI_IN_SIZE: u8 = 0x06;
-const MIDI_OUT_SIZE: u8 = 0x09;
+const MIDI_OUT_SIZE: u8 = 0x07;
 
 pub const MIDI_PACKET_SIZE: usize = 4;
 pub const MAX_PACKET_SIZE: usize = 64;
@@ -133,9 +133,7 @@ impl<B: UsbBus> UsbClass<B> for MidiClass<'_, B> {
                     MIDI_OUT_JACK_SUBTYPE,
                     EMBEDDED,
                     self.out_jack_id(i), //id
-                    0x01, // 1 pin
-                    self.in_jack_id(i), // pin 1
-                    0x01, //sorta vague source pin?
+                    0x00, // no pins
                     0x00
                 ]
             )?;


### PR DESCRIPTION
Hi,

thanks for your great work!

I made adjustments to support an arbitrary, user-selectable number of input and output MIDI ports (I have tested this with up to 16; however, usb-device needs to be patched as in https://github.com/Windfisch/usb-device/tree/buffer-sizes to allow for a control buffer size large enough to hold the rather large descriptors.).

Also I corrected the ports in the descriptor: It seems that the right way[tm] is to have one external in/out jack per embedded out/in jack; Windows ignores embedded jacks that aren't connected to any external jack (or other element possibly), while Linux does just fine.

Only one in/out pair can be used with the default settings, though, but by using the `control-buffer-256` feature of `usb-device`, up to 5 in/out port pairs can be used. Using more ports require aforementioned patch to usb-device.

_Note: [tdd.exe](https://www.thesycon.de/eng/usb_descriptordumper.shtml), a USB descriptor dumper and validator, still reports two errors (as with the original code): The in and out bulk endpoint descriptors are too short, because the MIDI audio class requires two more bytes. I've fixed this in https://github.com/Windfisch/usbd-midi (master), but this requires a [patched version of usb-device](https://github.com/Windfisch/usb-device/tree/endpoint_with_additional_data)._

I have changed the signature of the `new()` method; one might consider adding a differently-named function instead in order to retain compatibility.

If you have any questions or requests, give me a shout :).